### PR TITLE
Descomenta tabela CTD e adiciona nome dos trabalhos e autores

### DIFF
--- a/public/css/simposio/2025/educomp/custom.css
+++ b/public/css/simposio/2025/educomp/custom.css
@@ -111,6 +111,9 @@
           line-height: 1.2em;
           text-align: left;
         }
+        h3.titulo-secao {
+          text-align: center;
+        }
 
         h4.titulo-artigo {
           border: 0;

--- a/views/simposio/2025/educomp/pt-BR/chamadas/aceitos.handlebars
+++ b/views/simposio/2025/educomp/pt-BR/chamadas/aceitos.handlebars
@@ -327,7 +327,7 @@
               </div>
             </div>
 
-            <!-- <div class="card">
+            <div class="card">
               <div class="card-header" id="accordion-ctd">
                   <button class="btn btn-link w-100 text-left" type="button" data-toggle="collapse" data-target="#collapse-ctd" aria-expanded="true" aria-controls="collapse-ctd">
                     <h3>Concurso de Teses e Dissertações</h3>
@@ -340,20 +340,65 @@
                     <tbody class="text-left">
                       <tr>
                         <td>
-                          <h4 class="titulo-artigo">Lorem, ipsum dolor sit amet consectetur adipisicing elit.</h4>
+                          <h3 class="titulo-secao"><strong>Mestrado</strong></h3>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <h4 class="titulo-artigo">CoderBot: Um Assistente Virtual Para Apoiar a Aprendizagem de Programação por meio de Worked Examples</h4>
                           <ul class="autores-artigo">
-                            <li>Lorem, ipsum dolor sit</li>
-                            <li>Lorem, ipsum dolor sit</li>
-                            <li>Lorem, ipsum dolor sit</li>
+                            <li>Renato Garcia (UNIPAMPA)</li>
+                            <li>Pedro Henrique Dias Valle (USP)</li>
+                            <li>Williamson Silva (UNIPAMPA)</li>
                           </ul>
                         </td>
                       </tr>
                       <tr>
                         <td>
-                          <h4 class="titulo-artigo"></h4>
+                          <h4 class="titulo-artigo">Framework para auxílio no desenvolvimento de soft skills em estudantes de Engenharia de Software</h4>
                           <ul class="autores-artigo">
-                            <li></li>
-                            <li></li>
+                            <li>Giovana Giardini Borges (UNESP)</li>
+                          </ul>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <h4 class="titulo-artigo">NetVerse Edu – Um Laboratório Imersivo de Redes de Computadores no Metaverso como Ferramenta de Apoio às Práticas de Ensino</h4>
+                          <ul class="autores-artigo">
+                            <li>Erberson Vieira (IFPB)</li>
+                          </ul>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <h3 class="titulo-secao"><strong>Doutorado</strong></h3>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <h4 class="titulo-artigo">Estratégias para o Ensino de Machine Learning para Estudantes em Vulnerabilidade Social no Ensino Fundamental e Médio</h4>
+                          <ul class="autores-artigo">
+                            <li>Ramon Mayor Martins (IFSC)</li>
+                          </ul>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <h4 class="titulo-artigo">Exploring Equity and Self-Directed Learning in Computing Undergraduates: A Capability Analysis from the Global South</h4>
+                          <ul class="autores-artigo">
+                            <li>Esdras Bispo Jr. (UFJ)</li>
+                            <li>Simone Santos (UFPE)</li>
+                            <li>Marcus Vinicius De Matos (Brunel)</li>
+                          </ul>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <h4 class="titulo-artigo">Problemas de Compreensão em Códigos Corretos: Auxiliando Instrutores e Alunos ao Iluminar o que é Potencialmente Ofuscado pela Correção Automática</h4>
+                          <ul class="autores-artigo">
+                            <li>Eryck Silva (UNICAMP)</li>
+                            <li>Rodolfo J. Azevedo (UNICAMP)</li>
+                            <li>Ricardo Caceffo (Univesp)</li>
                           </ul>
                         </td>
                       </tr>
@@ -361,7 +406,7 @@
                   </table>
                 </div>
               </div>
-            </div> -->
+            </div>
 
             <div class="card">
               <div class="card-header" id="accordion-wtd">


### PR DESCRIPTION
-Adicionei os nomes do autores e trabalhos do CTD como pedido na tabela que já estava presente;
-Também adicionei os títulos Doutorado e Mestrado centralizados que não estavam na tabela original